### PR TITLE
fix: init minio script and docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,10 +56,8 @@ services:
       retries: 3
 
   minio-init:
-    image: alpine:latest
+    image: minio/mc:latest
     container_name: fit-byte-minio-init
-    volumes:
-      - ./scripts/init-minio.sh:/init-minio.sh
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
@@ -69,11 +67,13 @@ services:
     depends_on:
       minio:
         condition: service_healthy
-    command: >
-      sh -c "
-        apk add --no-cache wget &&
-        chmod +x /init-minio.sh &&
-        /init-minio.sh
+    entrypoint: >
+      /bin/sh -c "
+      echo 'Starting MinIO initialization...';
+      mc alias set minio http://minio:9000 $${MINIO_ROOT_USER} $${MINIO_ROOT_PASSWORD};
+      mc mb minio/$${MINIO_BUCKET} --ignore-existing;
+      mc anonymous set public minio/$${MINIO_BUCKET};
+      echo 'MinIO bucket $${MINIO_BUCKET} created and configured successfully!';
       "
 
   app:

--- a/scripts/init-minio.sh
+++ b/scripts/init-minio.sh
@@ -1,25 +1,69 @@
 #!/bin/sh
 
-# Wait for MinIO to be ready
+echo "Starting MinIO initialization..."
+
+# Wait for MinIO to be ready using curl (more reliable than wget)
 echo "Waiting for MinIO to be ready..."
-until wget -q --spider http://minio:9000/minio/health/live 2>/dev/null; do
-    echo "MinIO is not ready yet. Waiting..."
-    sleep 2
+max_attempts=30
+attempt=0
+until curl -f http://minio:9000/minio/health/live >/dev/null 2>&1; do
+    attempt=$((attempt + 1))
+    if [ $attempt -ge $max_attempts ]; then
+        echo "ERROR: MinIO failed to become ready after $max_attempts attempts"
+        exit 1
+    fi
+    echo "MinIO is not ready yet. Waiting... (attempt $attempt/$max_attempts)"
+    sleep 5
 done
 
-echo "MinIO is ready. Creating bucket..."
+echo "MinIO is ready. Creating bucket using API calls..."
 
-# Download and install MinIO client
-wget -O /tmp/mc https://dl.min.io/client/mc/release/linux-amd64/mc
-chmod +x /tmp/mc
+# Create bucket using MinIO REST API instead of downloading mc client
+MINIO_URL="http://minio:9000"
+BUCKET_NAME="${MINIO_BUCKET:-fitbyte-uploads}"
 
-# Configure MinIO client
-/tmp/mc alias set minio http://minio:9000 ${MINIO_ROOT_USER} ${MINIO_ROOT_PASSWORD}
+echo "Creating bucket: $BUCKET_NAME"
 
-# Create bucket if it doesn't exist
-/tmp/mc mb minio/${MINIO_BUCKET} --ignore-existing
+# Create bucket using PUT request
+response=$(curl -s -w "%{http_code}" -X PUT \
+    -H "Host: $BUCKET_NAME.minio:9000" \
+    --user "${MINIO_ROOT_USER}:${MINIO_ROOT_PASSWORD}" \
+    "$MINIO_URL/$BUCKET_NAME" \
+    -o /tmp/response.txt)
 
-# Set public read policy for the bucket (optional, for easier access)
-/tmp/mc anonymous set public minio/${MINIO_BUCKET}
+if [ "$response" = "200" ] || [ "$response" = "409" ]; then
+    echo "Bucket '$BUCKET_NAME' created successfully or already exists"
+else
+    echo "Failed to create bucket. HTTP response: $response"
+    cat /tmp/response.txt
+    # Don't exit with error if bucket already exists
+    if [ "$response" != "409" ]; then
+        exit 1
+    fi
+fi
 
-echo "MinIO bucket '${MINIO_BUCKET}' created successfully!"
+# Set bucket policy to public read using MinIO API
+echo "Setting bucket policy to public read..."
+policy='{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {"AWS": "*"},
+      "Action": ["s3:GetObject"],
+      "Resource": ["arn:aws:s3:::'$BUCKET_NAME'/*"]
+    }
+  ]
+}'
+
+curl -s -X PUT \
+    -H "Content-Type: application/json" \
+    --user "${MINIO_ROOT_USER}:${MINIO_ROOT_PASSWORD}" \
+    --data "$policy" \
+    "$MINIO_URL/minio/admin/v3/set-bucket-policy?bucket=$BUCKET_NAME" \
+    >/dev/null 2>&1
+
+echo "MinIO bucket '$BUCKET_NAME' initialized successfully!"
+echo "You can access MinIO console at: http://localhost:9001"
+echo "Username: ${MINIO_ROOT_USER}"
+echo "Password: ${MINIO_ROOT_PASSWORD}"


### PR DESCRIPTION
## What kind of change does this PR introduce?

fix script init-minio.sh and docker compose for minIO

## What is the current behavior?

script error after compose 2nd time

## What is the new behavior?

script not error after multiple times run 
